### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     image: politepol:latest
     depends_on:
       - 'dbpolitepol'
-    command: ["./wait-for-it.sh", "dbpolitepol:3306", "--", "/bin/bash", "./frontend/start.sh"]
+    command: ["./wait-for-it.sh", "dbpolitepol", "/bin/bash", "./frontend/start.sh"]
     container_name: politepol
     restart: unless-stopped
     networks:


### PR DESCRIPTION
I changed the wait-for-it.sh script because the ping test is not always enough to know if the database container has gone up.
It need to test the database connection to make sure mysql is live.

I was experiencing some errors regarding this (Don't connect on Mysql (111) ...) and now I think it's ok.